### PR TITLE
Add `xeus-python` to `environment.yml`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: example-environment
 channels:
+  - https://repo.mamba.pm/emscripten-forge
   - conda-forge
 dependencies:
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - toolz
   - matplotlib
   - dill
+  - xeus-python


### PR DESCRIPTION
Needed for https://github.com/jupyterlite/repo2jupyterlite/pull/19.

Based on the recent work for loading all Xeus-based kernels with a single `jupyterlite-xeus` utility package: https://jupyterlite-xeus.readthedocs.io/en/latest/environment.html